### PR TITLE
Update apigee_monitor.sh

### DIFF
--- a/apigee_monitor.sh
+++ b/apigee_monitor.sh
@@ -736,7 +736,7 @@ for row in $(cat ${apigee_conf_file} | jq -r ' .connection_details[] | @base64')
                     | [$identifier | gsub("( ? )"; ""), ($fivezerotwo_count | add)] | @tsv
                   ' <${fivezerotwo_curl_output} | sed 's/[][]//g;/^$/d;s/^[ \t]*//;s/[ \t]*$//' >jq_processed_502_response.out
 
-          found_502 ="true"
+          found_502="true"
 
           #502 BiQ Processor
           JSONProccessor ${fivezerotwo_curl_output} biq_502_raw.json
@@ -788,7 +788,7 @@ for row in $(cat ${apigee_conf_file} | jq -r ' .connection_details[] | @base64')
                     | [$identifier | gsub("( ? )"; ""), ($fivezerothree_count | add)] | @tsv
                   ' <${fivezerothree_curl_output} | sed 's/[][]//g;/^$/d;s/^[ \t]*//;s/[ \t]*$//' >jq_processed_503_response.out
 
-          found_503 ="true"
+          found_503="true"
 
           #503 BiQ Processor
           JSONProccessor ${fivezerothree_curl_output} biq_503_raw.json


### PR DESCRIPTION
Specifically, on lines 739 and 791, there is an extraneous space before the equals sign in the assignment;

line 739 
found_502 ="true"

line 791 
found_503 ="true"

This syntax error prevents the variable from being assigned correctly, leading to script failure. 

The assignment should be updated and committed as  

line 739 
found_502="true"

line 791 
found_503="true"
i.e. without the space.